### PR TITLE
change csv.createWriteStream to csv.format

### DIFF
--- a/lib/format.js
+++ b/lib/format.js
@@ -77,7 +77,7 @@ module.exports = (stream, format, columns, headers = true, maxLength = 30) => {
             );*/
         case 'csv':
         case 'tsv':
-            let formatStream = csv.createWriteStream({
+            let formatStream = csv.format({
                 headers,
                 delimiter: (format == 'tsv' ? '\t' : ',')
             })


### PR DESCRIPTION
fixes `TypeError: csv.createWriteStream is not a function` error when running `fec list --rss` on fresh install