### PR TITLE
use correct pg env vars when passing to fec-model

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -1,7 +1,9 @@
 const models = require('@publici/fec-model')({
     driver: 'postgres',
-    name: process.env.PGDATABASE || process.env.USER,
-    user: process.env.PGPASSWORD
+    host: process.env.PGHOST,
+    name: process.env.PGDATABASE,
+    user: process.env.PGUSER || process.env.USER,
+    pass: process.env.PGPASSWORD
 });
 
 module.exports = (options) => {


### PR DESCRIPTION
currently PGPASSWORD is being set to the user

this PR passes all the PG variables explicitly

it would be great to have an option to pass a db uri instead but it would require a PR on the `fec-model` side too so I haven't done that for now